### PR TITLE
Bring-up of state trie hash verification function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,7 @@ dependencies = [
  "derive_more",
  "fil_actor_eam",
  "fil_actor_evm",
+ "fil_actors_evm_shared",
  "fil_actors_runtime",
  "fil_builtin_actors_bundle",
  "fixed-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.0",
+ "gimli 0.27.2",
 ]
 
 [[package]]
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 dependencies = [
  "backtrace",
 ]
@@ -92,9 +92,6 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "async-channel"
@@ -200,9 +197,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -243,7 +240,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.30.2",
+ "object 0.30.3",
  "rustc-demangle",
 ]
 
@@ -320,13 +317,13 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.1.5",
+ "constant_time_eq 0.2.4",
 ]
 
 [[package]]
@@ -342,13 +339,13 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
+checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.1.5",
+ "constant_time_eq 0.2.4",
 ]
 
 [[package]]
@@ -471,12 +468,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
-dependencies = [
- "serde",
-]
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "castaway"
@@ -498,18 +492,18 @@ dependencies = [
 
 [[package]]
 name = "cbor4ii"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebce4be718fce03915a0a6220eaca81becdab6485d6ad57d483ed6ff76def7b7"
+checksum = "b544cf8c89359205f4f990d0e6f3828db42df85b5dac95d09157a250eb0749c4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -579,7 +573,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -897,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -907,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
 dependencies = [
  "fnv",
  "ident_case",
@@ -921,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
  "darling_core",
  "quote",
@@ -1069,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
@@ -1132,13 +1126,14 @@ dependencies = [
  "fil_actor_evm",
  "fil_actors_runtime",
  "fil_builtin_actors_bundle",
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "fvm",
  "fvm_integration_tests",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_kamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
+ "hash-db",
  "hex",
  "hex-literal",
  "indicatif",
@@ -1147,15 +1142,20 @@ dependencies = [
  "multihash",
  "num-traits",
  "num_cpus",
+ "plain_hasher",
+ "primitive-types",
  "rand",
  "rand_chacha",
+ "rlp",
  "ruint",
  "serde",
  "serde_json",
+ "sha3",
  "structopt",
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "triehash",
  "walkdir",
  "wasmtime",
  "wat",
@@ -1212,9 +1212,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1242,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_account"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "fil_actors_runtime",
@@ -1250,7 +1250,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "num-derive",
  "num-traits",
  "serde",
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0550a13a20decf920aeeb630a648b13174af5acf6b513895996ff1cd09393d"
+checksum = "4a3138c84b845e64c6ad0c50ef299f954d979bd265c8b74509a22b9d1b8107e0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1278,12 +1278,12 @@ dependencies = [
 [[package]]
 name = "fil_actor_cron"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "log",
  "num-derive",
  "num-traits",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_datacap"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "cid",
  "fil_actors_runtime",
@@ -1302,8 +1302,8 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
  "num-derive",
@@ -1314,14 +1314,15 @@ dependencies = [
 [[package]]
 name = "fil_actor_eam"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "cid",
+ "fil_actors_evm_shared",
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "hex-literal",
  "log",
  "multihash",
@@ -1335,13 +1336,13 @@ dependencies = [
 [[package]]
 name = "fil_actor_ethaccount"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "fil_actors_runtime",
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "hex-literal",
  "num-derive",
  "num-traits",
@@ -1351,43 +1352,32 @@ dependencies = [
 [[package]]
 name = "fil_actor_evm"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
- "arrayvec 0.7.2",
- "bytes",
  "cid",
- "derive_more",
+ "fil_actors_evm_shared",
  "fil_actors_runtime",
- "fixed-hash 0.7.0",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_kamt",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "hex",
  "hex-literal",
- "impl-serde",
- "lazy_static",
  "log",
  "multihash",
- "near-blake2",
  "num-derive",
  "num-traits",
- "once_cell",
- "rlp",
  "serde",
  "serde_tuple",
- "strum",
- "strum_macros",
  "substrate-bn",
- "uint",
 ]
 
 [[package]]
 name = "fil_actor_init"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "cid",
@@ -1395,8 +1385,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_shared 3.0.0-alpha.20",
  "log",
  "num-derive",
  "num-traits",
@@ -1406,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_market"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "cid",
@@ -1416,8 +1406,8 @@ dependencies = [
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_shared 3.0.0-alpha.20",
  "integer-encoding",
  "libipld-core 0.13.1",
  "log",
@@ -1429,19 +1419,19 @@ dependencies = [
 [[package]]
 name = "fil_actor_miner"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "byteorder",
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_amt 0.5.1",
+ "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_shared 3.0.0-alpha.20",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -1454,7 +1444,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_multisig"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "cid",
@@ -1463,8 +1453,8 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_shared 3.0.0-alpha.20",
  "indexmap",
  "integer-encoding",
  "num-derive",
@@ -1475,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_paych"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "cid",
@@ -1483,7 +1473,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "num-derive",
  "num-traits",
  "serde",
@@ -1492,16 +1482,12 @@ dependencies = [
 [[package]]
 name = "fil_actor_placeholder"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
-dependencies = [
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
-]
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 
 [[package]]
 name = "fil_actor_power"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "cid",
@@ -1509,8 +1495,8 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_shared 3.0.0-alpha.20",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -1523,12 +1509,12 @@ dependencies = [
 [[package]]
 name = "fil_actor_reward"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
  "num-derive",
@@ -1539,14 +1525,14 @@ dependencies = [
 [[package]]
 name = "fil_actor_system"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "cid",
  "fil_actors_runtime",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "num-derive",
  "num-traits",
  "serde",
@@ -1555,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "fil_actor_verifreg"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "cid",
@@ -1565,8 +1551,8 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
  "num-derive",
@@ -1575,22 +1561,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actors_evm_shared"
+version = "10.0.0-alpha.1"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
+dependencies = [
+ "fil_actors_runtime",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0-alpha.20",
+ "hex",
+ "serde",
+ "uint",
+]
+
+[[package]]
 name = "fil_actors_runtime"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "anyhow",
  "blake2b_simd",
  "byteorder",
  "castaway",
  "cid",
- "fvm_ipld_amt 0.5.1",
+ "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_sdk 3.0.0-alpha.22",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_sdk 3.0.0-alpha.24",
+ "fvm_shared 3.0.0-alpha.20",
  "hex",
  "itertools 0.10.5",
  "lazy_static",
@@ -1614,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "fil_builtin_actors_bundle"
 version = "10.0.0-alpha.1"
-source = "git+https://github.com/filecoin-project/builtin-actors?branch=next#89d2aec3da0be9d0a9e08d67a09e85a50b7be0e9"
+source = "git+https://github.com/shamb0/builtin-actors?branch=shamb0/mirror-next#94a93434d60d6cb621f77e9d87718ab419fe98a1"
 dependencies = [
  "cid",
  "clap 3.2.23",
@@ -1622,6 +1621,7 @@ dependencies = [
  "fil_actor_bundler",
  "fil_actor_cron",
  "fil_actor_datacap",
+ "fil_actor_eam",
  "fil_actor_ethaccount",
  "fil_actor_evm",
  "fil_actor_init",
@@ -1711,19 +1711,12 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
+ "byteorder",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1734,7 +1727,7 @@ version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
- "spin 0.9.4",
+ "spin 0.9.5",
 ]
 
 [[package]]
@@ -1778,15 +1771,15 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "3.0.0"
+version = "3.0.1-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a093747f6447d7528cf37b87b8ab9879c7417e960d2ea1ac523890eb3a924e2a"
+checksum = "b9d7a133ea05356dbb3115ddb6bb302a9cb82efcc7561602ed687c277d96e55b"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
- "fvm_ipld_encoding 0.2.3",
- "fvm_sdk 2.2.0",
- "fvm_shared 2.0.0",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_sdk 3.0.0-alpha.24",
+ "fvm_shared 3.0.0-alpha.20",
  "thiserror",
 ]
 
@@ -1816,20 +1809,20 @@ dependencies = [
 
 [[package]]
 name = "frc46_token"
-version = "3.1.0"
+version = "4.0.1-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112bdb7d37e58715087146b19465f59374e8cffd81561a8d20dbdb1eb2c75fbe"
+checksum = "d88d59160be82c91c9ba8dd4d670693ab826178a1d94ae792ded0d6b92a723cd"
 dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_amt 0.4.2",
+ "fvm_ipld_amt",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_ipld_hamt 0.5.1",
- "fvm_sdk 2.2.0",
- "fvm_shared 2.0.0",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_ipld_hamt",
+ "fvm_sdk 3.0.0-alpha.24",
+ "fvm_shared 3.0.0-alpha.20",
  "integer-encoding",
  "num-traits",
  "serde",
@@ -1855,9 +1848,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1870,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1880,15 +1873,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1897,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -1918,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1929,21 +1922,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1959,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.0.0-alpha.21"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c7dbfb0057877303d2efb4d9ab6657f2b70fe326d8d95580426c337faca2ca"
+checksum = "9efd2ca858542b73acd5f679bac84ab9de2af8ccb35a3528e414e08b85e55982"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -1972,11 +1965,11 @@ dependencies = [
  "derive_more",
  "filecoin-proofs-api",
  "fvm-wasm-instrument",
- "fvm_ipld_amt 0.5.1",
+ "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
  "minstant",
@@ -2012,17 +2005,17 @@ dependencies = [
 
 [[package]]
 name = "fvm_actor_utils"
-version = "3.0.0"
+version = "4.0.1-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a11cab1852eb6f381cc11ebcfa6b2c84d3df5b5603ab6c79d6b02761718da77"
+checksum = "f2d45c603677e42634b25f52aff45db3d57a7f46c524e6d528489e193564cc38"
 dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "fvm_sdk 2.2.0",
- "fvm_shared 2.0.0",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_sdk 3.0.0-alpha.24",
+ "fvm_shared 3.0.0-alpha.20",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -2031,20 +2024,20 @@ dependencies = [
 
 [[package]]
 name = "fvm_integration_tests"
-version = "3.0.0-alpha.1"
+version = "3.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c1e48273a137606a7438072e5a18883559763d6416fcb8309f9b4fb17fae0"
+checksum = "d8bbca161c18cb1d4dd749c1a1342b83770dacac3a0fdda79ce1469d90c7d1e4"
 dependencies = [
  "anyhow",
  "cid",
  "futures",
  "fvm",
- "fvm_ipld_amt 0.5.1",
+ "fvm_ipld_amt",
  "fvm_ipld_blockstore",
  "fvm_ipld_car",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_ipld_hamt",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "libsecp256k1",
  "multihash",
@@ -2056,23 +2049,6 @@ dependencies = [
  "serde_tuple",
  "thiserror",
  "wasmtime",
-]
-
-[[package]]
-name = "fvm_ipld_amt"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d09e5aa7de45452676d18fcb70b750acd65faae7a4fe18fe784b4c85f869fb"
-dependencies = [
- "ahash",
- "anyhow",
- "cid",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "itertools 0.10.5",
- "once_cell",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -2166,27 +2142,6 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_hamt"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b5c939897aa1bfd63e7cb9c458ba10689371af3278ff20d66c6f8ca152c6c0"
-dependencies = [
- "anyhow",
- "byteorder",
- "cid",
- "cs_serde_bytes",
- "forest_hash_utils",
- "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.2.3",
- "libipld-core 0.13.1",
- "multihash",
- "once_cell",
- "serde",
- "sha2 0.10.6",
- "thiserror",
-]
-
-[[package]]
-name = "fvm_ipld_hamt"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c942494dde990aeac314311bde34c787be99cab7d0836397a75556cbaa2c3e7"
@@ -2241,13 +2196,13 @@ dependencies = [
 
 [[package]]
 name = "fvm_sdk"
-version = "3.0.0-alpha.22"
+version = "3.0.0-alpha.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51908aab9e7564fbcb278d78e31c12402b68c70517661780feb29adbb234aaf"
+checksum = "ad163015237811580399ce929938f3bdca2d1a133672ff01693f555a632ec425"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.0.0-alpha.17",
+ "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
  "num-traits",
@@ -2285,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.17"
+version = "3.0.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779876441e390f414161474701404b5641e02a5b9acfece9b212f6d24e482e1"
+checksum = "b594b4d4c1393f03e3430f106c09874fcac565e68a560686de37ca2982a61d1a"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2358,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
@@ -2394,6 +2349,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash-db"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -2440,6 +2401,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"
@@ -2494,12 +2458,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-serde"
-version = "0.3.2"
+name = "impl-codec"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2562,12 +2555,12 @@ checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2596,9 +2589,9 @@ checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2783,7 +2776,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
 dependencies = [
- "rustix 0.36.7",
+ "rustix 0.36.8",
 ]
 
 [[package]]
@@ -2884,7 +2877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
  "blake2b_simd",
- "blake2s_simd 1.0.0",
+ "blake2s_simd 1.0.1",
  "blake3",
  "core2",
  "digest 0.10.6",
@@ -2909,16 +2902,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "near-blake2"
-version = "0.9.1"
-source = "git+https://github.com/filecoin-project/near-blake2.git#47a58e5061ba6d6c1132f535188b7fde2f67bcb2"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -3082,18 +3065,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -3129,6 +3112,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637935964ff85a605d114591d4d2c13c5d1ba2806dae97cea6bf180238a749ac"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3181,6 +3190,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plain_hasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "polling"
@@ -3242,6 +3260,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,9 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -3504,16 +3535,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 1.0.4",
+ "io-lifetimes 1.0.5",
  "libc",
  "linux-raw-sys 0.1.4",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3569,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -3601,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -3749,9 +3780,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
 dependencies = [
  "lock_api",
 ]
@@ -3925,25 +3956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
 name = "substrate-bn"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3993,9 +4005,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "temp-env"
@@ -4066,10 +4078,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -4093,9 +4106,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -4165,6 +4178,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triehash"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
+dependencies = [
+ "hash-db",
+ "rlp",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4205,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -4297,9 +4320,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4307,9 +4330,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -4322,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4334,9 +4357,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4344,9 +4367,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4357,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-encoder"
@@ -4372,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef126be0e14bdf355ac1a8b41afc89195289e5c7179f80118e3abddb472f0810"
+checksum = "704553b4d614a47080b4a457a976b3c16174b19ce95b931b847561b590dd09ba"
 dependencies = [
  "leb128",
 ]
@@ -4400,9 +4423,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.98.1"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8724c724dc595495979c055f4bd8b7ed9fab1069623178a28016ae43a9666f36"
+checksum = "9cc3222d9e47412382cc95e2f013c6a9f510bcff80af92de5665ae3ec1e4a2f6"
 dependencies = [
  "indexmap",
  "url",
@@ -4410,12 +4433,12 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.48"
+version = "0.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322949f382cd5e4bad4330e144bf2124b3182846194ac01e2423c07a6a15ba85"
+checksum = "abfea0b7816054bcad689e7c68a6f957eb023d0e70f69835db400f1a51ad7dec"
 dependencies = [
  "anyhow",
- "wasmparser 0.98.1",
+ "wasmparser 0.101.0",
 ]
 
 [[package]]
@@ -4566,30 +4589,30 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "52.0.1"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829fb867c8e82d21557a2c6c5b3ed8e8f7cdd534ea782b9ecf68bede5607fe4b"
+checksum = "f0d3df4a63b10958fe98ab9d7e9a57a7bc900209d2b4edd10535bfb0703e6516"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.22.0",
+ "wasm-encoder 0.24.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.55"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3493e7c82d8e9a75e69ecbfe6f324ca1c4e2ae89f67ccbb22f92282e2e27bb23"
+checksum = "3e9a7c7d177696d0548178c36e377d49eba54170e885801d4270e2d44e82ac84"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4664,6 +4687,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc 0.42.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,7 +1269,7 @@ dependencies = [
  "clap 3.2.23",
  "futures",
  "fvm_ipld_blockstore",
- "fvm_ipld_car",
+ "fvm_ipld_car 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_encoding 0.3.3",
  "serde",
  "serde_ipld_dagcbor",
@@ -1303,7 +1303,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
@@ -1386,7 +1386,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 3.0.0-alpha.20",
  "log",
  "num-derive",
@@ -1407,7 +1407,7 @@ dependencies = [
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 3.0.0-alpha.20",
  "integer-encoding",
  "libipld-core 0.13.1",
@@ -1427,11 +1427,11 @@ dependencies = [
  "cid",
  "fil_actors_runtime",
  "frc42_dispatch",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 3.0.0-alpha.20",
  "itertools 0.10.5",
  "lazy_static",
@@ -1454,7 +1454,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 3.0.0-alpha.20",
  "indexmap",
  "integer-encoding",
@@ -1496,7 +1496,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 3.0.0-alpha.20",
  "indexmap",
  "integer-encoding",
@@ -1552,7 +1552,7 @@ dependencies = [
  "fvm_actor_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
@@ -1584,11 +1584,11 @@ dependencies = [
  "byteorder",
  "castaway",
  "cid",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_sdk 3.0.0-alpha.24",
  "fvm_shared 3.0.0-alpha.20",
  "hex",
@@ -1818,10 +1818,10 @@ dependencies = [
  "cid",
  "frc42_dispatch",
  "fvm_actor_utils",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fvm_sdk 3.0.0-alpha.24",
  "fvm_shared 3.0.0-alpha.20",
  "integer-encoding",
@@ -1954,8 +1954,6 @@ dependencies = [
 [[package]]
 name = "fvm"
 version = "3.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efd2ca858542b73acd5f679bac84ab9de2af8ccb35a3528e414e08b85e55982"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -1966,10 +1964,10 @@ dependencies = [
  "derive_more",
  "filecoin-proofs-api",
  "fvm-wasm-instrument",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "log",
@@ -1979,6 +1977,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "once_cell",
+ "primitive-types",
  "rand",
  "rayon",
  "replace_with",
@@ -2026,18 +2025,16 @@ dependencies = [
 [[package]]
 name = "fvm_integration_tests"
 version = "3.0.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bbca161c18cb1d4dd749c1a1342b83770dacac3a0fdda79ce1469d90c7d1e4"
 dependencies = [
  "anyhow",
  "cid",
  "futures",
  "fvm",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore",
- "fvm_ipld_car",
+ "fvm_ipld_car 0.6.0",
  "fvm_ipld_encoding 0.3.3",
- "fvm_ipld_hamt",
+ "fvm_ipld_hamt 0.6.1",
  "fvm_shared 3.0.0-alpha.20",
  "lazy_static",
  "libsecp256k1",
@@ -2050,6 +2047,20 @@ dependencies = [
  "serde_tuple",
  "thiserror",
  "wasmtime",
+]
+
+[[package]]
+name = "fvm_ipld_amt"
+version = "0.5.1"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.3",
+ "itertools 0.10.5",
+ "once_cell",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -2083,12 +2094,23 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688239a96199577f6705a3f9689abfd795f867f91f5847bc7e236017cc672df7"
 dependencies = [
  "anyhow",
  "cid",
  "multihash",
+]
+
+[[package]]
+name = "fvm_ipld_car"
+version = "0.6.0"
+dependencies = [
+ "cid",
+ "futures",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.3",
+ "integer-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -2127,8 +2149,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_encoding"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
 dependencies = [
  "anyhow",
  "cid",
@@ -2138,6 +2158,24 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_repr",
  "serde_tuple",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_hamt"
+version = "0.6.1"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cid",
+ "forest_hash_utils",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.3",
+ "libipld-core 0.14.0",
+ "multihash",
+ "once_cell",
+ "serde",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -2164,8 +2202,6 @@ dependencies = [
 [[package]]
 name = "fvm_ipld_kamt"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab54acc8b19c5029ceefb3a1aa5708e1513a6ef7b17cdfeb6674c042b70d163"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2242,8 +2278,6 @@ dependencies = [
 [[package]]
 name = "fvm_shared"
 version = "3.0.0-alpha.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b594b4d4c1393f03e3430f106c09874fcac565e68a560686de37ca2982a61d1a"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2792,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -3744,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -3977,9 +4011,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4396,9 +4430,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704553b4d614a47080b4a457a976b3c16174b19ce95b931b847561b590dd09ba"
+checksum = "68f7d56227d910901ce12dfd19acc40c12687994dfb3f57c90690f80be946ec5"
 dependencies = [
  "leb128",
 ]
@@ -4424,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.101.0"
+version = "0.101.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc3222d9e47412382cc95e2f013c6a9f510bcff80af92de5665ae3ec1e4a2f6"
+checksum = "bf2f22ef84ac5666544afa52f326f13e16f3d019d2e61e704fd8091c9358b130"
 dependencies = [
  "indexmap",
  "url",
@@ -4434,12 +4468,12 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.51"
+version = "0.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfea0b7816054bcad689e7c68a6f957eb023d0e70f69835db400f1a51ad7dec"
+checksum = "003f2e37b9b7caac949d388e185ecd9139f51441249a23880b0cf38e10cdf647"
 dependencies = [
  "anyhow",
- "wasmparser 0.101.0",
+ "wasmparser 0.101.1",
 ]
 
 [[package]]
@@ -4590,21 +4624,21 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "54.0.0"
+version = "54.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d3df4a63b10958fe98ab9d7e9a57a7bc900209d2b4edd10535bfb0703e6516"
+checksum = "3d48d9d731d835f4f8dacbb8de7d47be068812cb9877f5c60d408858778d8d2a"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.24.0",
+ "wasm-encoder 0.24.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9a7c7d177696d0548178c36e377d49eba54170e885801d4270e2d44e82ac84"
+checksum = "d1db2e3ed05ea31243761439194bec3af6efbbaf87c4c8667fb879e4f23791a0"
 dependencies = [
  "wast",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,14 +51,23 @@ fvm_integration_tests = { version = "3.0.0-alpha.3" }
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
 fil_actor_evm = { package = "fil_actor_evm", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
 fil_actors_evm_shared = { package = "fil_actors_evm_shared", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
-fil_actor_eam = { package = "fil_actor_eam", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
 fil_actors_runtime = { package = "fil_actors_runtime", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next", features = ["test_utils"] }
 
+[dev-dependencies]
+fil_actor_eam = { package = "fil_actor_eam", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
 
 [dependencies.wasmtime]
 version = "2.0.2"
 default-features = false
 features = ["cranelift", "parallel-compilation"]
+
+[patch.crates-io]
+fvm = { path = "../fork02-ref-fvm/ref-fvm/fvm" }
+fvm_ipld_kamt = { path = "../fork02-ref-fvm/ref-fvm/ipld/kamt" }
+fvm_ipld_blockstore = { path = "../fork02-ref-fvm/ref-fvm/ipld/blockstore" }
+fvm_ipld_encoding = { path = "../fork02-ref-fvm/ref-fvm/ipld/encoding" }
+fvm_integration_tests = { path = "../fork02-ref-fvm/ref-fvm/testing/integration" }
+fvm_shared = { path = "../fork02-ref-fvm/ref-fvm/shared" }
 
 #[patch.crates-io]
 #fvm_shared = { git = "https://github.com/filecoin-project/ref-fvm", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ fvm_integration_tests = { version = "3.0.0-alpha.3" }
 
 actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
 fil_actor_evm = { package = "fil_actor_evm", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
+fil_actors_evm_shared = { package = "fil_actors_evm_shared", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
 fil_actor_eam = { package = "fil_actor_eam", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
 fil_actors_runtime = { package = "fil_actors_runtime", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next", features = ["test_utils"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,12 @@ ruint = { version = "1.7.0", features = ["rlp", "serde"] }
 hex = { version = "0.4" }
 fixed-hash = { version = "0.8", default-features = false, features = ["rustc-hex"]}
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
+primitive-types = { version = "0.12", features = ["rlp", "serde"] }
+hash-db = "0.15"
+plain_hasher = "0.2"
+rlp = { version = "0.5", default-features = false }
+sha3 = { version = "0.10", default-features = false }
+triehash = "0.8"
 hex-literal = "0.3"
 derive_more = "0.99"
 lazy_static = "1.4.0"
@@ -35,17 +41,17 @@ serde_json = "1.0"
 walkdir = "2.3"
 multihash = { version = "0.16.1", default-features = false }
 
-fvm = { version = "3.0.0-alpha.21", default-features = false, features = ["testing"] }
+fvm = { version = "3.0.0-rc.1", default-features = false, features = ["testing"] }
 fvm_ipld_kamt = { version = "0.2.0" }
 fvm_ipld_blockstore = "0.1.1"
 fvm_ipld_encoding = "0.3.3"
-fvm_shared = { version = "3.0.0-alpha.17", default-features = false }
-fvm_integration_tests = { version = "3.0.0-alpha.1" }
+fvm_shared = { version = "3.0.0-alpha.20", default-features = false }
+fvm_integration_tests = { version = "3.0.0-alpha.3" }
 
-actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["m2-native"] }
-fil_actor_evm = { package = "fil_actor_evm", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
-fil_actor_eam = { package = "fil_actor_eam", git = "https://github.com/filecoin-project/builtin-actors", branch = "next" }
-fil_actors_runtime = { package = "fil_actors_runtime", git = "https://github.com/filecoin-project/builtin-actors", branch = "next", features = ["test_utils"] }
+actors-v10 = { package = "fil_builtin_actors_bundle", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
+fil_actor_evm = { package = "fil_actor_evm", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
+fil_actor_eam = { package = "fil_actor_eam", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next" }
+fil_actors_runtime = { package = "fil_actors_runtime", git = "https://github.com/shamb0/builtin-actors", branch = "shamb0/mirror-next", features = ["test_utils"] }
 
 
 [dependencies.wasmtime]

--- a/src/common/builtin.rs
+++ b/src/common/builtin.rs
@@ -10,7 +10,7 @@ use fvm_ipld_encoding::CborStore;
 use fvm_shared::ActorID;
 use multihash::Code;
 
-use crate::common::error::Error::{FailedToLoadManifest, FailedToSetActor, FailedToSetState};
+use super::error::Error::{FailedToLoadManifest, FailedToSetState};
 
 // Retrieve system, init and accounts actors code CID
 pub fn fetch_builtin_code_cid(
@@ -45,10 +45,8 @@ pub fn set_sys_actor(
         balance: Default::default(),
         delegated_address: None,
     };
-    state_tree
-        .set_actor(system_actor::SYSTEM_ACTOR_ID, sys_actor_state)
-        .map_err(anyhow::Error::from)
-        .context(FailedToSetActor("system actor".to_owned()))
+    state_tree.set_actor(system_actor::SYSTEM_ACTOR_ID, sys_actor_state);
+    Ok(())
 }
 
 pub fn set_init_actor(
@@ -69,10 +67,8 @@ pub fn set_init_actor(
         delegated_address: None,
     };
 
-    state_tree
-        .set_actor(init_actor::INIT_ACTOR_ID, init_actor_state)
-        .map_err(anyhow::Error::from)
-        .context(FailedToSetActor("init actor".to_owned()))
+    state_tree.set_actor(init_actor::INIT_ACTOR_ID, init_actor_state);
+    Ok(())
 }
 
 pub fn set_eam_actor(state_tree: &mut StateTree<impl Blockstore>, eam_code_cid: Cid) -> Result<()> {
@@ -91,8 +87,7 @@ pub fn set_eam_actor(state_tree: &mut StateTree<impl Blockstore>, eam_code_cid: 
         delegated_address: None,
     };
 
-    state_tree
-        .set_actor(EAM_ACTOR_ID, eam_actor_state)
-        .map_err(anyhow::Error::from)
-        .context(FailedToSetActor("eam actor".to_owned()))
+    state_tree.set_actor(EAM_ACTOR_ID, eam_actor_state);
+
+    Ok(())
 }

--- a/src/common/merkle_trie.rs
+++ b/src/common/merkle_trie.rs
@@ -1,0 +1,24 @@
+use bytes::Bytes;
+use hash_db::Hasher;
+use plain_hasher::PlainHasher;
+use sha3::{Digest, Keccak256};
+pub use triehash::sec_trie_root;
+
+use super::{B256, H160, H256};
+
+pub fn trie_root(acc_data: Vec<(H160, Bytes)>) -> B256 {
+    B256(sec_trie_root::<KeccakHasher, _, _, _>(acc_data.into_iter()).0)
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct KeccakHasher;
+
+impl Hasher for KeccakHasher {
+    type Out = H256;
+    type StdHasher = PlainHasher;
+    const LENGTH: usize = 32;
+    fn hash(x: &[u8]) -> Self::Out {
+        let out = Keccak256::digest(x);
+        H256::from_slice(out.as_slice())
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,6 +1,7 @@
 mod bits;
 pub mod builtin;
 mod error;
+pub mod merkle_trie;
 mod skip;
 mod system;
 pub mod tester;
@@ -9,6 +10,7 @@ extern crate alloc;
 
 pub use bits::{B160, B256};
 pub use error::Error;
+pub use primitive_types::{H160, H256};
 pub use ruint::aliases::U256;
 pub use skip::SKIP_TESTS;
 pub use system::system_find_all_json_tests;

--- a/src/statetest/executor.rs
+++ b/src/statetest/executor.rs
@@ -164,8 +164,6 @@ impl<'a, T: Tester> Executor<'a, T> {
                 return false;
             };
 
-        let sender_actor_id = *self.pre_contract_cache.get(&sender).unwrap();
-
         // Process the "Post" & "transaction" block
         unit.post.iter().for_each(|(spec_name, tests)| {
             tests.iter().for_each(|test| {
@@ -186,7 +184,7 @@ impl<'a, T: Tester> Executor<'a, T> {
 
                 let _execu_status = self.process_post_block_internal(
                     runner.clone(),
-                    sender_actor_id,
+                    sender,
                     name,
                     spec_name,
                     unit,
@@ -234,7 +232,7 @@ impl<'a, T: Tester> Executor<'a, T> {
     fn process_post_block_internal<RUN: Runner + Clone>(
         &mut self,
         runner: RUN,
-        sender_id: ActorID,
+        sender: B160,
         name: &str,
         spec_name: &SpecName,
         unit: &TestUnit,
@@ -287,11 +285,13 @@ impl<'a, T: Tester> Executor<'a, T> {
 
         let actor_address = Address::new_id(*actor_id);
 
-        let sender_addr = Address::new_id(sender_id);
+		let sender_actor_id = *self.pre_contract_cache.get(&sender).unwrap();
 
-        let sender_address = Address::new_delegated(EAM_ACTOR_ID, &sender_addr.to_bytes()).unwrap();
+        let sender_address = Address::new_delegated(EAM_ACTOR_ID, &sender.to_fixed_bytes()).unwrap();
 
-        let sender_state = self.tester.get_actor(sender_id).unwrap().unwrap();
+        let sender_state = self.tester.get_actor(sender_actor_id).unwrap().unwrap();
+
+		info!("Sender :: {:#?} {:#?}", &sender, &sender_address);
 
         // Gas::new(tx_gas_limit).as_milligas(),
         // Gas::from_milligas(tx_gas_limit).as_milligas()

--- a/src/statetest/executor.rs
+++ b/src/statetest/executor.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use std::time::Instant;
 
 use fil_actors_runtime::runtime::builtins::Type as ActorType;
+use fil_actors_runtime::runtime::EMPTY_ARR_CID;
 use fvm::executor::ApplyKind;
 use fvm::gas::Gas;
 use fvm::state_tree::ActorState;
@@ -437,26 +438,36 @@ impl<'a, T: Tester> Executor<'a, T> {
 						address
 					);
                 }
+                // Create an account if the bytecode is empty, otherwise create an EVM actor.
+                let (code_cid, state_cid) = if info.code.is_empty() {
+                    let ethaccount_code_cid = self
+                        .tester
+                        .code_by_id(ActorType::EthAccount as u32)
+                        .unwrap();
+                    (ethaccount_code_cid, EMPTY_ARR_CID)
+                } else {
+                    let evm_code_cid = self.tester.code_by_id(ActorType::EVM as u32).unwrap();
+                    let evm_state_cid = self
+                        .tester
+                        .init_fevm(
+                            info.code.clone(),
+                            info.nonce,
+                            &info.storage,
+                            KAMT_CONFIG.clone(),
+                        )
+                        .expect("failed to store state");
 
-                let evm_code_cid = self.tester.code_by_id(ActorType::EVM as u32).unwrap();
-                let evm_state_cid = self
-                    .tester
-                    .init_fevm(
-                        info.code.clone(),
-                        info.nonce,
-                        &info.storage,
-                        KAMT_CONFIG.clone(),
-                    )
-                    .expect("failed to store state");
+                    (evm_code_cid, evm_state_cid)
+                };
 
                 let actor_state = ActorState::new(
-                    evm_code_cid,
-                    evm_state_cid,
+                    code_cid,
+                    state_cid,
                     TokenAmount::from_atto(
                         BigInt::from_str(&format!("{}", &info.balance)).unwrap(),
                     ),
                     info.nonce,
-                    None,
+                    Some(addr),
                 );
 
                 let actor_id = self

--- a/src/statetest/executor.rs
+++ b/src/statetest/executor.rs
@@ -472,7 +472,7 @@ where
                 info!(
                     "Balance :: {:#?}",
                     self.tester
-                        .get_actor(actor_id.clone())
+                        .get_actor(actor_id)
                         .unwrap()
                         .map(|actor_state| {
                             primitive_types::U256::from_dec_str(&format!(

--- a/src/statetest/executor.rs
+++ b/src/statetest/executor.rs
@@ -283,15 +283,16 @@ impl<'a, T: Tester> Executor<'a, T> {
             .get(&unit.transaction.to.unwrap())
             .unwrap();
 
-        let actor_address = Address::new_id(*actor_id);
+        let to_actor_address = Address::new_id(*actor_id);
 
-		let sender_actor_id = *self.pre_contract_cache.get(&sender).unwrap();
+        let sender_actor_id = *self.pre_contract_cache.get(&sender).unwrap();
 
-        let sender_address = Address::new_delegated(EAM_ACTOR_ID, &sender.to_fixed_bytes()).unwrap();
+        let sender_address =
+            Address::new_delegated(EAM_ACTOR_ID, &sender.to_fixed_bytes()).unwrap();
 
         let sender_state = self.tester.get_actor(sender_actor_id).unwrap().unwrap();
 
-		info!("Sender :: {:#?} {:#?}", &sender, &sender_address);
+        info!("Sender :: {:#?} {:#?}", &sender, &sender_address);
 
         // Gas::new(tx_gas_limit).as_milligas(),
         // Gas::from_milligas(tx_gas_limit).as_milligas()
@@ -301,7 +302,7 @@ impl<'a, T: Tester> Executor<'a, T> {
         // Send message
         let message = Message {
             from: sender_address,
-            to: actor_address,
+            to: to_actor_address,
             sequence: sender_state.sequence,
             gas_limit: tx_gas_limit.saturating_mul(20u64),
             method_num: fil_actor_evm::Method::InvokeContract as u64,

--- a/src/statetest/runner.rs
+++ b/src/statetest/runner.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration};
+use std::time::Duration;
 
 use indicatif::ProgressBar;
 use tracing::{error, info, trace};
@@ -83,7 +83,7 @@ impl Runner for RunnerCore {
 
     fn print_summary(&self) {
         if let Ok(runner_stats) = self.exe_status.lock() {
-			println!("=== Start ===");
+            println!("=== Start ===");
             println!("=== OK Status ===");
             if runner_stats.ok_list.is_empty() {
                 println!("None");
@@ -107,7 +107,7 @@ impl Runner for RunnerCore {
                 println!("Count :: {:#?}", runner_stats.skip_list.len());
                 println!("{:#?}", &runner_stats.skip_list);
             }
-			println!("=== End ===");
+            println!("=== End ===");
         }
     }
 }

--- a/test-vectors/skip_test.json
+++ b/test-vectors/skip_test.json
@@ -175,28 +175,6 @@
                     }
                 }
             }
-        },
-        {
-            "issueId": "ID-0096 | stQuadraticComplexityTest/QuadraticComplexitySolidity_CallDataCopy.json",
-            "failing": "Very long execution time in loop",
-            "postTests": {
-                "QuadraticComplexitySolidity_CallDataCopy": {
-                    "skipIds": {
-                        "Istanbul" : [
-                            "*"
-                        ],
-                        "Berlin" : [
-                            "*"
-                        ],
-                        "London" : [
-                            "*"
-                        ],
-                        "Merge" : [
-                            "*"
-                        ]
-                    }
-                }
-            }
         }
     ]
 }


### PR DESCRIPTION
Bring-up of state trie hash verification function.

Observing mismatch in hash value under FEVM context.

**Summary**

> Modified test vector with single transaction, common test vector used in both fevm & revm context.

- [mod-push0.json](https://github.com/shamb0/fevm-eth-compliance-test-trace/blob/main/GeneralStateTests/EIPTests/stEIP3855/TID-01-04-01-mod-push0.json#L1)

> Mismatch in computed state trie hash value under FEVM context

- [Complete Trace](https://github.com/shamb0/fevm-eth-compliance-test-trace/blob/main/GeneralStateTests/EIPTests/stEIP3855/TID-01-04-02-fevm.md#L5)

![](https://i.imgur.com/mPsxG4G.png)

> Computed state trie hash value under revm context

- [Complete Trace](https://github.com/shamb0/fevm-eth-compliance-test-trace/blob/main/GeneralStateTests/EIPTests/stEIP3855/TID-01-04-03-revm.md#L1)

![](https://i.imgur.com/7HFCCvc.png)

## Difference in state properties values, used for calculating state trie hash.

> Mismatch in bytecode hash

**FEVM context**

![](https://i.imgur.com/4RYKHN4.png)

**revm context**

![](https://i.imgur.com/khzcxfa.png)

> Mismatch in slot status @0000000000000000000000000000000000000400

**FEVM context**

![](https://i.imgur.com/raRb2yr.png)

**revm context**

![](https://i.imgur.com/gpTyU5A.png)

